### PR TITLE
chore: promote review to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/review/review-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/review/review-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-16T21:30:37Z"
+  creationTimestamp: "2021-01-17T22:29:33Z"
   deletionTimestamp: null
-  name: 'review-0.0.1'
+  name: 'review-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: ad308a7041e0c9b2af3666b4ff2e5ecdc9063fb4
+        chore: release 0.0.2
+      sha: 75d4ba8b336c492dc3e979ccb4e308d492d91272
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 45e5e84e5fcbf162ec0e11a146607ca5b0235208
+      sha: 4ca4437534b3e29825d3046d1a5be31047b8b15c
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -38,12 +38,12 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        chore: Jenkins X build pack
-      sha: 6e75c9063dcf05b083f1fe87f1280b74dde934bc
+        add: sonarqube condigs
+      sha: aa1be5ab2573cc65d91f7e3f466092de727bba2f
   gitHttpUrl: https://github.com/BaPipe/review
   gitOwner: BaPipe
   gitRepository: review
   name: 'review'
-  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
+++ b/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: review-review
   labels:
     draft: draft-app
-    chart: "review-0.0.1"
+    chart: "review-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: review-review
       containers:
         - name: review
-          image: "gcr.io/fair-expanse-297121/review:0.0.1"
+          image: "gcr.io/fair-expanse-297121/review:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/review/review-svc.yaml
+++ b/config-root/namespaces/jx-staging/review/review-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: review
   labels:
-    chart: "review-0.0.1"
+    chart: "review-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.68.60.17.nip.io/
 releases:
 - chart: dev/review
-  version: 0.0.1
+  version: 0.0.2
   name: review
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote review to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge