### PR TITLE
chore: promote review to version 0.0.8

### DIFF
--- a/config-root/namespaces/jx-staging/review/review-0.0.8-release.yaml
+++ b/config-root/namespaces/jx-staging/review/review-0.0.8-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-22T22:26:47Z"
+  creationTimestamp: "2021-01-22T22:59:39Z"
   deletionTimestamp: null
-  name: 'review-0.0.7'
+  name: 'review-0.0.8'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.7
-      sha: bfa311246b09fb2c93fe8fc0a4f141c8fe453bdf
+        chore: release 0.0.8
+      sha: 1f7c343751456b12e30436abd7f4d928cdee27f2
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 4e8fcbed2bafec6859fe3aa3a9f9b46a47d2b12a
+      sha: 8e56bf935986876d29561c365a0915da13e11790
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -38,8 +38,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        fix: sonarqube triggered in pull request now
-      sha: 267e7c974c2f9544f5b36e59aa070477ec2bacbf
+        test: gitops test number 2
+      sha: 67fd7f937fb32784edcaec6a1c5ef0e2b5c6c375
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -48,12 +48,12 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        feat: added sonarqube task to pipeline
-      sha: 34678a00dcdccb0868658954c25282267f21a677
+        test: gitops test
+      sha: 64f7e09f1fed59e85d39cebec9442720fa8214eb
   gitHttpUrl: https://github.com/BaPipe/review
   gitOwner: BaPipe
   gitRepository: review
   name: 'review'
-  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.7
-  version: v0.0.7
+  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.8
+  version: v0.0.8
 status: {}

--- a/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
+++ b/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: review-review
   labels:
     draft: draft-app
-    chart: "review-0.0.7"
+    chart: "review-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: review-review
       containers:
         - name: review
-          image: "gcr.io/fair-expanse-297121/review:0.0.7"
+          image: "gcr.io/fair-expanse-297121/review:0.0.8"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.7
+              value: 0.0.8
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/review/review-svc.yaml
+++ b/config-root/namespaces/jx-staging/review/review-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: review
   labels:
-    chart: "review-0.0.7"
+    chart: "review-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.68.60.17.nip.io/
 releases:
 - chart: dev/review
-  version: 0.0.7
+  version: 0.0.8
   name: review
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote review to version 0.0.8

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge