### PR TITLE
chore: promote review to version 0.0.14

### DIFF
--- a/config-root/namespaces/jx-staging/review/review-0.0.14-release.yaml
+++ b/config-root/namespaces/jx-staging/review/review-0.0.14-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-24T13:51:38Z"
+  creationTimestamp: "2021-01-29T12:28:55Z"
   deletionTimestamp: null
-  name: 'review-0.0.13'
+  name: 'review-0.0.14'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.13
-      sha: 3dcf2cb8aa8edb01a1a098597cbac68ddda04524
+        chore: release 0.0.14
+      sha: 0748f09d595040771bc79d20e11228ad8a183a1a
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: e84e7c14fc33877fac39174e91be236cf3763112
+      sha: 10f33e10c7e40677d7a3984dce91c38f916b43d6
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -38,8 +38,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        fix: trying pr
-      sha: aed73fd9ed8c57e3cea0396ced683d072e981b73
+        feat: test pr
+      sha: 7ac0c3bc9f917cef2d5557389c7f2831490ecc6e
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -48,8 +48,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        fix: testing pipeline pr number 2
-      sha: a930557a5058eef751e430d5ff7270daecc4c294
+        fix: changed sonarqube to pr; test pipeline
+      sha: 9b0304a938464cfa3bdfd1fbe5db81641cc821de
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -58,12 +58,12 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        fix: testing pipeline pr
-      sha: 8e1244cd0923bca18bd196b6f1c5a5becedec49c
+        fix: added sonarqube to release and removed from pullrequest
+      sha: ac650dcfe535d79343e32aec3fe0ef0595ff8355
   gitHttpUrl: https://github.com/BaPipe/review
   gitOwner: BaPipe
   gitRepository: review
   name: 'review'
-  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.13
-  version: v0.0.13
+  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.14
+  version: v0.0.14
 status: {}

--- a/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
+++ b/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: review-review
   labels:
     draft: draft-app
-    chart: "review-0.0.13"
+    chart: "review-0.0.14"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: review-review
       containers:
         - name: review
-          image: "gcr.io/fair-expanse-297121/review:0.0.13"
+          image: "gcr.io/fair-expanse-297121/review:0.0.14"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.13
+              value: 0.0.14
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/review/review-svc.yaml
+++ b/config-root/namespaces/jx-staging/review/review-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: review
   labels:
-    chart: "review-0.0.13"
+    chart: "review-0.0.14"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.68.60.17.nip.io/
 releases:
 - chart: dev/review
-  version: 0.0.13
+  version: 0.0.14
   name: review
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote review to version 0.0.14

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge