### PR TITLE
chore: promote review to version 0.0.16

### DIFF
--- a/config-root/namespaces/jx-production/review/review-0.0.16-release.yaml
+++ b/config-root/namespaces/jx-production/review/review-0.0.16-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-21T15:56:08Z"
+  creationTimestamp: "2021-01-30T13:15:17Z"
   deletionTimestamp: null
-  name: 'review-0.0.4'
+  name: 'review-0.0.16'
   namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.4
-      sha: 0d41a0833308c27b06d2205b456637105fc5b2ce
+        chore: release 0.0.16
+      sha: 374463777936fe831a7d65287f8ff43756e4ed37
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 81552ccbf58d1657de7ebd30bb6732fc9c007798
+      sha: 7ae7c635c4c61ee5ff2c5f1ccf69b319964a4b1e
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -38,8 +38,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        test: ip with http #2
-      sha: 17aa0f4fa83d1eea5694d3d0db9c973cc9b714e0
+        fix: test 3
+      sha: 6e8ac57c8f2e27c7c4f70d4ac88b29ad989841a2
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -48,8 +48,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        test: ip with http
-      sha: aaabaf89e7a3cd80549e822be705fad89bab07d9
+        fix: pipeline test2
+      sha: afe9d5ed56a01e7a622dd9ef28ab0419430b02c1
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -58,12 +58,42 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        add: sonarqube and call command in pipeline
-      sha: d704ccff6373a39bd0ec491dbac41456d7da3221
+        feat: test pipe
+      sha: 77650255f6bef3af76240eedf56e8bdf1ec3269e
+    - author:
+        email: saschazauner@aol.com
+        name: Sascha
+      branch: master
+      committer:
+        email: saschazauner@aol.com
+        name: Sascha
+      message: |
+        fix: test 2
+      sha: ba67d9135fa4ad61fa68a42b78e93112d6382bbd
+    - author:
+        email: saschazauner@aol.com
+        name: Sascha
+      branch: master
+      committer:
+        email: saschazauner@aol.com
+        name: Sascha
+      message: |
+        fix: test
+      sha: 683da19d8f2857690a30f8f00414b7e90ee10f98
+    - author:
+        email: saschazauner@aol.com
+        name: Sascha
+      branch: master
+      committer:
+        email: saschazauner@aol.com
+        name: Sascha
+      message: |
+        feat: triger gets sonarqube
+      sha: 9c2602e7ee187e99f581c66c9bf8aff9e229266e
   gitHttpUrl: https://github.com/BaPipe/review
   gitOwner: BaPipe
   gitRepository: review
   name: 'review'
-  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.4
-  version: v0.0.4
+  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.16
+  version: v0.0.16
 status: {}

--- a/config-root/namespaces/jx-production/review/review-review-deploy.yaml
+++ b/config-root/namespaces/jx-production/review/review-review-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: review-review
   labels:
     draft: draft-app
-    chart: "review-0.0.4"
+    chart: "review-0.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: review-review
       containers:
         - name: review
-          image: "gcr.io/fair-expanse-297121/review:0.0.4"
+          image: "gcr.io/fair-expanse-297121/review:0.0.16"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.16
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-production/review/review-svc.yaml
+++ b/config-root/namespaces/jx-production/review/review-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: review
   labels:
-    chart: "review-0.0.4"
+    chart: "review-0.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.68.60.17.nip.io/
 releases:
 - chart: dev/review
-  version: 0.0.4
+  version: 0.0.16
   name: review
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote review to version 0.0.16

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge