### PR TITLE
chore: promote review to version 0.0.18

### DIFF
--- a/config-root/namespaces/jx-production/review/review-0.0.18-release.yaml
+++ b/config-root/namespaces/jx-production/review/review-0.0.18-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-21T15:56:08Z"
+  creationTimestamp: "2021-01-31T14:49:23Z"
   deletionTimestamp: null
-  name: 'review-0.0.4'
+  name: 'review-0.0.18'
   namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.4
-      sha: 0d41a0833308c27b06d2205b456637105fc5b2ce
+        chore: release 0.0.18
+      sha: b9368991f284df6b51dbe3697ce4ad861d43b86a
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 81552ccbf58d1657de7ebd30bb6732fc9c007798
+      sha: 75d028d54e97ceea40a3da8678f811a28d755443
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -38,8 +38,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        test: ip with http #2
-      sha: 17aa0f4fa83d1eea5694d3d0db9c973cc9b714e0
+        test: triggering pr 2
+      sha: 23f6841cf4cc8cec2b6f55c9b61f164de90b0806
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -48,8 +48,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        test: ip with http
-      sha: aaabaf89e7a3cd80549e822be705fad89bab07d9
+        test: triggering pr
+      sha: c7e132e4e64d84af35f51893826f70a2e4837175
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -58,12 +58,12 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        add: sonarqube and call command in pipeline
-      sha: d704ccff6373a39bd0ec491dbac41456d7da3221
+        fix: fixing pipeline with sonar from release to pr pipeline (maybe) 2
+      sha: 4dced08ddc135dd084534cbbd1c402b1cbe69604
   gitHttpUrl: https://github.com/BaPipe/review
   gitOwner: BaPipe
   gitRepository: review
   name: 'review'
-  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.4
-  version: v0.0.4
+  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.18
+  version: v0.0.18
 status: {}

--- a/config-root/namespaces/jx-production/review/review-review-deploy.yaml
+++ b/config-root/namespaces/jx-production/review/review-review-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: review-review
   labels:
     draft: draft-app
-    chart: "review-0.0.4"
+    chart: "review-0.0.18"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: review-review
       containers:
         - name: review
-          image: "gcr.io/fair-expanse-297121/review:0.0.4"
+          image: "gcr.io/fair-expanse-297121/review:0.0.18"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.18
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-production/review/review-svc.yaml
+++ b/config-root/namespaces/jx-production/review/review-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: review
   labels:
-    chart: "review-0.0.4"
+    chart: "review-0.0.18"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/jx-staging/review/review-0.0.18-release.yaml
+++ b/config-root/namespaces/jx-staging/review/review-0.0.18-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-31T13:13:19Z"
+  creationTimestamp: "2021-01-31T14:49:23Z"
   deletionTimestamp: null
-  name: 'review-0.0.17'
+  name: 'review-0.0.18'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.17
-      sha: 930cdba0e4d6a6289944da27cb43e762f46ef64a
+        chore: release 0.0.18
+      sha: b9368991f284df6b51dbe3697ce4ad861d43b86a
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 355137b67e64aa8233e3d009aabbee4352a411ba
+      sha: 75d028d54e97ceea40a3da8678f811a28d755443
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -38,8 +38,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        fix: fixing pipeline with sonar from release to pr pipeline (maybe)
-      sha: bf62de7e45fd8768253e645e02235b8c620c0ceb
+        test: triggering pr 2
+      sha: 23f6841cf4cc8cec2b6f55c9b61f164de90b0806
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -48,8 +48,8 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        fix: testing pipeline if working 2
-      sha: 8b3abcfa2b70bfff9a3f09ef43c1f2c55caa397b
+        test: triggering pr
+      sha: c7e132e4e64d84af35f51893826f70a2e4837175
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -58,22 +58,12 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        test: trigger release pipeline
-      sha: b4c6f82e5ad58e71d5fc99bc0f35c0a2dd7ca7e9
-    - author:
-        email: saschazauner@aol.com
-        name: Sascha
-      branch: master
-      committer:
-        email: saschazauner@aol.com
-        name: Sascha
-      message: |
-        feat: added Sonarqube analyse to release
-      sha: 59e769733138e7d31b83c1988716196f1be4cd5f
+        fix: fixing pipeline with sonar from release to pr pipeline (maybe) 2
+      sha: 4dced08ddc135dd084534cbbd1c402b1cbe69604
   gitHttpUrl: https://github.com/BaPipe/review
   gitOwner: BaPipe
   gitRepository: review
   name: 'review'
-  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.17
-  version: v0.0.17
+  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.18
+  version: v0.0.18
 status: {}

--- a/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
+++ b/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: review-review
   labels:
     draft: draft-app
-    chart: "review-0.0.17"
+    chart: "review-0.0.18"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: review-review
       containers:
         - name: review
-          image: "gcr.io/fair-expanse-297121/review:0.0.17"
+          image: "gcr.io/fair-expanse-297121/review:0.0.18"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.17
+              value: 0.0.18
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/review/review-svc.yaml
+++ b/config-root/namespaces/jx-staging/review/review-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: review
   labels:
-    chart: "review-0.0.17"
+    chart: "review-0.0.18"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.68.60.17.nip.io/
 releases:
 - chart: dev/review
-  version: 0.0.4
+  version: 0.0.18
   name: review
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.68.60.17.nip.io/
 releases:
 - chart: dev/review
-  version: 0.0.17
+  version: 0.0.18
   name: review
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote review to version 0.0.18

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge