### PR TITLE
chore: promote review to version 0.0.19

### DIFF
--- a/config-root/namespaces/jx-staging/review/review-0.0.19-release.yaml
+++ b/config-root/namespaces/jx-staging/review/review-0.0.19-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-31T14:49:23Z"
+  creationTimestamp: "2021-01-31T15:39:22Z"
   deletionTimestamp: null
-  name: 'review-0.0.18'
+  name: 'review-0.0.19'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.18
-      sha: b9368991f284df6b51dbe3697ce4ad861d43b86a
+        chore: release 0.0.19
+      sha: 527dd90f72db7b79dda6b9f8d4ce122c7278a1af
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 75d028d54e97ceea40a3da8678f811a28d755443
+      sha: b006ea64a67bd6b3bf86c7e246a2dba3f4516fa8
     - author:
         email: saschazauner@aol.com
         name: Sascha
@@ -38,32 +38,12 @@ spec:
         email: saschazauner@aol.com
         name: Sascha
       message: |
-        test: triggering pr 2
-      sha: 23f6841cf4cc8cec2b6f55c9b61f164de90b0806
-    - author:
-        email: saschazauner@aol.com
-        name: Sascha
-      branch: master
-      committer:
-        email: saschazauner@aol.com
-        name: Sascha
-      message: |
-        test: triggering pr
-      sha: c7e132e4e64d84af35f51893826f70a2e4837175
-    - author:
-        email: saschazauner@aol.com
-        name: Sascha
-      branch: master
-      committer:
-        email: saschazauner@aol.com
-        name: Sascha
-      message: |
-        fix: fixing pipeline with sonar from release to pr pipeline (maybe) 2
-      sha: 4dced08ddc135dd084534cbbd1c402b1cbe69604
+        fix: added sonnarqube again
+      sha: 9550ceb8466d7ce0eb8d12ee9efc40edd6780264
   gitHttpUrl: https://github.com/BaPipe/review
   gitOwner: BaPipe
   gitRepository: review
   name: 'review'
-  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.18
-  version: v0.0.18
+  releaseNotesURL: https://github.com/BaPipe/review/releases/tag/v0.0.19
+  version: v0.0.19
 status: {}

--- a/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
+++ b/config-root/namespaces/jx-staging/review/review-review-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: review-review
   labels:
     draft: draft-app
-    chart: "review-0.0.18"
+    chart: "review-0.0.19"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: review-review
       containers:
         - name: review
-          image: "gcr.io/fair-expanse-297121/review:0.0.18"
+          image: "gcr.io/fair-expanse-297121/review:0.0.19"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.18
+              value: 0.0.19
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/review/review-svc.yaml
+++ b/config-root/namespaces/jx-staging/review/review-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: review
   labels:
-    chart: "review-0.0.18"
+    chart: "review-0.0.19"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.68.60.17.nip.io/
 releases:
 - chart: dev/review
-  version: 0.0.18
+  version: 0.0.19
   name: review
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote review to version 0.0.19

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge